### PR TITLE
ExecuteQuery - Add an option to specify API version

### DIFF
--- a/Frends.Salesforce.ExecuteQuery/CHANGELOG.md
+++ b/Frends.Salesforce.ExecuteQuery/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.0] - 2024-08-19
+### Added
+- Salesforce API version number can now be specified in input.
+
 ## [1.0.1] - 2022-05-27
 ### Changed
 - Fix for issue with referencing result-object in other elements.

--- a/Frends.Salesforce.ExecuteQuery/Frends.Salesforce.ExecuteQuery.Tests/UnitTests.cs
+++ b/Frends.Salesforce.ExecuteQuery/Frends.Salesforce.ExecuteQuery.Tests/UnitTests.cs
@@ -37,7 +37,8 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
-            Query = "SELECT Name from Customer"
+            Query = "SELECT Name from Customer",
+            ApiVersion = "v61.0"
         };
 
         var options = new Options
@@ -56,7 +57,8 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
-            Query = "SELECT Name from Customer"
+            Query = "SELECT Name from Customer",
+            ApiVersion = "v61.0"
         };
 
         var options = new Options
@@ -80,7 +82,8 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
-            Query = "SELECT Name from Customer"
+            Query = "SELECT Name from Customer",
+            ApiVersion = "v61.0"
         };
 
         var options = new Options
@@ -101,6 +104,26 @@ public class UnitTests
         Assert.AreEqual(result.Token, accessToken);
     }
 
+    public async Task ExecuteQuery_QueryWithoutSpecifiedApi()
+    {
+        var input = new Input
+        {
+            Domain = _domain,
+            Query = "SELECT Name from Customer",
+            ApiVersion = ""
+        };
+
+        var options = new Options
+        {
+            AuthenticationMethod = AuthenticationMethod.AccessToken,
+            AccessToken = await Salesforce.GetAccessToken(_authurl, _clientID, _clientSecret, _username, _password + _securityToken, _cancellationToken)
+        };
+
+        var result = await Salesforce.ExecuteQuery(input, options, _cancellationToken);
+        Assert.IsTrue(result.RequestIsSuccessful);
+    }
+
+
     [TestMethod]
     [ExpectedException(typeof(ArgumentNullException))]
     public async Task EmptyQuery_ThrowTest()
@@ -108,7 +131,8 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
-            Query = null
+            Query = null,
+            ApiVersion = "v61.0"
         };
 
         var options = new Options
@@ -127,7 +151,8 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
-            Query = "SELECT Name from Customer"
+            Query = "SELECT Name from Customer",
+            ApiVersion = "v61.0"
         };
 
         var options = new Options
@@ -146,7 +171,8 @@ public class UnitTests
         var input = new Input
         {
             Domain = null,
-            Query = "SELECT Name from Customer"
+            Query = "SELECT Name from Customer",
+            ApiVersion = "v61.0"
         };
 
         var options = new Options
@@ -165,7 +191,8 @@ public class UnitTests
         var input = new Input
         {
             Domain = "https://mycompany.my.salesforce.com",
-            Query = "SELECT Name from Customer"
+            Query = "SELECT Name from Customer",
+            ApiVersion = "v61.0"
         };
 
         var options = new Options
@@ -183,7 +210,8 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
-            Query = "SELECT NAME from Invalid"
+            Query = "SELECT NAME from Invalid",
+            ApiVersion = "v61.0"
         };
 
         var options = new Options

--- a/Frends.Salesforce.ExecuteQuery/Frends.Salesforce.ExecuteQuery/Definitions/Input.cs
+++ b/Frends.Salesforce.ExecuteQuery/Frends.Salesforce.ExecuteQuery/Definitions/Input.cs
@@ -18,6 +18,13 @@ public class Input
     public string Domain { get; set; }
 
     /// <summary>
+    /// The API version to use when making requests to Salesforce.
+    /// Default value is the latest version at this moment (v61.0).
+    /// </summary>
+    [DefaultValue("v61.0")]
+    public string ApiVersion { get; set; } = "v61.0";
+
+    /// <summary>
     /// Query which will be executed.
     /// </summary>
     /// <example>SELECT Name from Customer</example>

--- a/Frends.Salesforce.ExecuteQuery/Frends.Salesforce.ExecuteQuery/Definitions/Input.cs
+++ b/Frends.Salesforce.ExecuteQuery/Frends.Salesforce.ExecuteQuery/Definitions/Input.cs
@@ -10,7 +10,7 @@ public class Input
 {
     /// <summary>
     /// Salesforce Domain.
-    /// /services/data/v52.0/query will be added automatically, so the domain is enough.
+    /// /services/data/versionnumber/query will be added automatically, so the domain is enough.
     /// </summary>
     /// <example>https://example.my.salesforce.com</example>
     [DefaultValue(@"https://example.my.salesforce.com")]
@@ -19,7 +19,7 @@ public class Input
 
     /// <summary>
     /// The API version to use when making requests to Salesforce.
-    /// Default value is the latest version at this moment (v61.0).
+    /// If left empty, the default value is v61.0.
     /// </summary>
     [DefaultValue("v61.0")]
     public string ApiVersion { get; set; } = "v61.0";

--- a/Frends.Salesforce.ExecuteQuery/Frends.Salesforce.ExecuteQuery/ExecuteQuery.cs
+++ b/Frends.Salesforce.ExecuteQuery/Frends.Salesforce.ExecuteQuery/ExecuteQuery.cs
@@ -33,7 +33,7 @@ public class Salesforce
         if (string.IsNullOrWhiteSpace(input.Query)) throw new ArgumentNullException("Query cannot be empty.");
 
         var query = WebUtility.UrlEncode(input.Query);
-        var client = new RestClient(input.Domain + "/services/data/v54.0/query/?q=" + query);
+        var client = new RestClient($"{input.Domain}/services/data/{input.ApiVersion}/query/?q={query}");
         var request = new RestRequest("/", Method.Get);
         string accessToken = "";
 

--- a/Frends.Salesforce.ExecuteQuery/Frends.Salesforce.ExecuteQuery/Frends.Salesforce.ExecuteQuery.csproj
+++ b/Frends.Salesforce.ExecuteQuery/Frends.Salesforce.ExecuteQuery/Frends.Salesforce.ExecuteQuery.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Version>1.0.1</Version>
+    <Version>2.0.0</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>


### PR DESCRIPTION
Closes #21 . Major version bump to 2.0.0. You can now specify API-version in the input-section. If left empty, the latest version as of today will be used (v61.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to specify the Salesforce API version number for enhanced flexibility during API interactions.

- **Bug Fixes**
	- Previous version (1.1.0) corrected the documentation link, ensuring it directs to the correct page.
	- Previous version (1.0.1) addressed bugs related to referencing result objects.

- **Documentation**
	- Updated changelog to reflect the release of version 2.0.0 and the addition of the API version feature.

- **Version Update**
	- Updated the module version from 1.0.1 to 2.0.0, indicating significant enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->