### PR TITLE
CreateSObject - Added option to specify API version

### DIFF
--- a/Frends.Salesforce.CreateSObject/CHANGELOG.md
+++ b/Frends.Salesforce.CreateSObject/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.0] - 2024-08-19
+### Added
+- Salesforce API version number can now be specified in input.
+
 ## [1.0.1] - 2022-05-27
 ### Changed
 - Fix for issue with referencing result-object in other elements.

--- a/Frends.Salesforce.CreateSObject/Frends.Salesforce.CreateSObject.Tests/UnitTests.cs
+++ b/Frends.Salesforce.CreateSObject/Frends.Salesforce.CreateSObject.Tests/UnitTests.cs
@@ -82,6 +82,25 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
+            SObjectAsJson = _userJson,
+            SObjectType = "Account"
+        };
+
+        var result = await Salesforce.CreateSObject(input, _options, _cancellationToken);
+        Assert.IsTrue(result.RequestIsSuccessful);
+
+        var body = JsonConvert.SerializeObject(result.Body);
+        var obj = JsonConvert.DeserializeObject<dynamic>(body);
+        _result.Add(new { Type = "Account", Id = obj.id });
+    }
+
+    [TestMethod]
+    public async Task CreateAccountTest_WithoutSpecifiedApiVersion()
+    {
+        var input = new Input
+        {
+            Domain = _domain,
             SObjectAsJson = _userJson,
             SObjectType = "Account"
         };
@@ -107,6 +126,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectAsJson = json,
             SObjectType = "Contact"
         };
@@ -126,6 +146,7 @@ public class UnitTests
         var accountInput = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectAsJson = _userJson,
             SObjectType = "Account"
         };
@@ -148,6 +169,7 @@ public class UnitTests
         var caseInput = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectAsJson = json,
             SObjectType = "Case"
         };
@@ -166,6 +188,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectAsJson = _userJson,
             SObjectType = "Account"
         };
@@ -195,6 +218,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectAsJson = _userJson,
             SObjectType = "Contact"
         };
@@ -215,6 +239,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = null,
+            ApiVersion = "v61.0",
             SObjectAsJson = _userJson,
             SObjectType = "Account"
         };
@@ -235,6 +260,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectAsJson = null,
             SObjectType = "Account"
         };
@@ -255,6 +281,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectAsJson = _userJson,
             SObjectType = ""
         };
@@ -275,6 +302,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = "https://mycompany.my.salesforce.com",
+            ApiVersion = "v61.0",
             SObjectAsJson = _userJson,
             SObjectType = "Account"
         };
@@ -298,6 +326,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectAsJson = _userJson,
             SObjectType = "InvalidType"
         };
@@ -322,6 +351,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectAsJson = _userJson,
             SObjectType = "Account"
         };
@@ -347,6 +377,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectAsJson = "Not valid json format",
             SObjectType = "Account"
         };

--- a/Frends.Salesforce.CreateSObject/Frends.Salesforce.CreateSObject/CreateSObject.cs
+++ b/Frends.Salesforce.CreateSObject/Frends.Salesforce.CreateSObject/CreateSObject.cs
@@ -31,7 +31,7 @@ public class Salesforce
         if (string.IsNullOrWhiteSpace(input.SObjectAsJson)) throw new ArgumentNullException("Json cannot be empty.");
         if (string.IsNullOrWhiteSpace(input.SObjectType)) throw new ArgumentNullException("Type cannot be empty.");
 
-        var client = new RestClient(input.Domain + "/services/data/v54.0/sobjects/" + input.SObjectType);
+        var client = new RestClient($"{input.Domain}/services/data/{input.ApiVersion}/sobjects/{input.SObjectType}");
         var request = new RestRequest("/", Method.Post);
         string accessToken = "";
 

--- a/Frends.Salesforce.CreateSObject/Frends.Salesforce.CreateSObject/Definitions/Input.cs
+++ b/Frends.Salesforce.CreateSObject/Frends.Salesforce.CreateSObject/Definitions/Input.cs
@@ -17,6 +17,13 @@ public class Input
     public string Domain { get; set; }
 
     /// <summary>
+    /// The API version to use when making requests to Salesforce.
+    /// If left empty, the default value is the v61.0.
+    /// </summary>
+    [DefaultValue("v61.0")]
+    public string ApiVersion { get; set; } = "v61.0";
+
+    /// <summary>
     /// SObject structure as json.
     /// </summary>
     /// <example>{ "Name": "ExampleName" }</example>

--- a/Frends.Salesforce.CreateSObject/Frends.Salesforce.CreateSObject/Definitions/Input.cs
+++ b/Frends.Salesforce.CreateSObject/Frends.Salesforce.CreateSObject/Definitions/Input.cs
@@ -9,7 +9,7 @@ public class Input
 {
     /// <summary>
     /// Salesforce Domain.
-    /// /services/data/v52.0/query will be added automatically, so the domain is enough.
+    /// /services/data/versionnumber/query will be added automatically, so the domain is enough.
     /// </summary>
     /// <example>https://example.my.salesforce.com</example>
     [DefaultValue(@"https://example.my.salesforce.com")]
@@ -18,7 +18,7 @@ public class Input
 
     /// <summary>
     /// The API version to use when making requests to Salesforce.
-    /// If left empty, the default value is the v61.0.
+    /// If left empty, the default value is v61.0.
     /// </summary>
     [DefaultValue("v61.0")]
     public string ApiVersion { get; set; } = "v61.0";

--- a/Frends.Salesforce.CreateSObject/Frends.Salesforce.CreateSObject/Frends.Salesforce.CreateSObject.csproj
+++ b/Frends.Salesforce.CreateSObject/Frends.Salesforce.CreateSObject/Frends.Salesforce.CreateSObject.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>1.0.1</Version>
+    <Version>2.0.0</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>


### PR DESCRIPTION
Closes #19 . Major version bump to 2.0.0. You can now specify API-version in the input-section. If left empty, the latest version as of today will be used (v61.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to specify the Salesforce API version when creating SObjects, enhancing flexibility and compatibility with different environments.
  
- **Testing Improvements**
	- Increased test coverage for `CreateSObject` functionality, including new tests for API version handling and improved consistency across existing tests. 

- **Version Update**
	- Updated module version from 1.0.1 to 2.0.0 to reflect new features and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->