### PR TITLE
DeleteSObject - Added option to specify API version

### DIFF
--- a/Frends.Salesforce.DeleteSObject/CHANGELOG.md
+++ b/Frends.Salesforce.DeleteSObject/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.0] - 2024-08-19
+### Added
+- Salesforce API version number can now be specified in input.
+
 ## [1.0.1] - 2022-05-27
 ### Changed
 - Fix for issue with referencing result-object in other elements.

--- a/Frends.Salesforce.DeleteSObject/Frends.Salesforce.DeleteSObject.Tests/UnitTests.cs
+++ b/Frends.Salesforce.DeleteSObject/Frends.Salesforce.DeleteSObject.Tests/UnitTests.cs
@@ -58,6 +58,15 @@ public class UnitTests
     public async Task DeleteAccountTest()
     {
         var id = await CreateSObject("Account", _userJson);
+        var result = await Salesforce.DeleteSObject(new Input { Domain = _domain, ApiVersion = "v61.0", SObjectId = id, SObjectType = "Account" }, _options, _cancellationToken);
+
+        Assert.IsTrue(result.RequestIsSuccessful);
+    }
+
+    [TestMethod]
+    public async Task DeleteAccountTest_WithoutSpecifiedApiVersion()
+    {
+        var id = await CreateSObject("Account", _userJson);
         var result = await Salesforce.DeleteSObject(new Input { Domain = _domain, SObjectId = id, SObjectType = "Account" }, _options, _cancellationToken);
 
         Assert.IsTrue(result.RequestIsSuccessful);
@@ -74,7 +83,7 @@ public class UnitTests
             });
 
         var id = await CreateSObject("Contact", json);
-        var result = await Salesforce.DeleteSObject(new Input { Domain = _domain, SObjectId = id, SObjectType = "Contact" }, _options, _cancellationToken);
+        var result = await Salesforce.DeleteSObject(new Input { Domain = _domain, ApiVersion = "v61.0", SObjectId = id, SObjectType = "Contact" }, _options, _cancellationToken);
 
         Assert.IsTrue(result.RequestIsSuccessful);
     }
@@ -96,10 +105,10 @@ public class UnitTests
 
         var caseId = await CreateSObject("Case", json);
 
-        var caseResult = await Salesforce.DeleteSObject(new Input { Domain = _domain, SObjectId = caseId, SObjectType = "Case" }, _options, _cancellationToken);
+        var caseResult = await Salesforce.DeleteSObject(new Input { Domain = _domain, ApiVersion = "v61.0", SObjectId = caseId, SObjectType = "Case" }, _options, _cancellationToken);
         Assert.IsTrue(caseResult.RequestIsSuccessful);
 
-        var accountResult = await Salesforce.DeleteSObject(new Input { Domain = _domain, SObjectId = accountId, SObjectType = "Account" }, _options, _cancellationToken);
+        var accountResult = await Salesforce.DeleteSObject(new Input { Domain = _domain, ApiVersion = "v61.0", SObjectId = accountId, SObjectType = "Account" }, _options, _cancellationToken);
         Assert.IsTrue(accountResult.RequestIsSuccessful);
     }
 
@@ -117,7 +126,7 @@ public class UnitTests
             Password = _password + _securityToken,
             ReturnAccessToken = true
         };
-        var result = await Salesforce.DeleteSObject(new Input { Domain = _domain, SObjectId = id, SObjectType = "Account" }, options, _cancellationToken);
+        var result = await Salesforce.DeleteSObject(new Input { Domain = _domain, ApiVersion = "v61.0", SObjectId = id, SObjectType = "Account" }, options, _cancellationToken);
 
         Assert.IsNotNull(result.Token);
     }
@@ -129,6 +138,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectId = "123456789",
             SObjectType = "Contact"
         };
@@ -149,6 +159,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = null,
+            ApiVersion = "v61.0",
             SObjectId = "123456789",
             SObjectType = "Account"
         };
@@ -169,6 +180,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectId = null,
             SObjectType = "Account"
         };
@@ -189,6 +201,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectId = "123456789",
             SObjectType = ""
         };
@@ -209,6 +222,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = "https://mycompany.my.salesforce.com",
+            ApiVersion = "v61.0",
             SObjectId = "123456789",
             SObjectType = "Account"
         };
@@ -232,6 +246,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectId = "123456789",
             SObjectType = "InvalidType"
         };
@@ -256,6 +271,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectId = "123456789",
             SObjectType = "Account"
         };
@@ -280,6 +296,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectId = "Not valid id",
             SObjectType = "Account"
         };
@@ -301,6 +318,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectId = "123456789",
             SObjectType = "Account"
         };

--- a/Frends.Salesforce.DeleteSObject/Frends.Salesforce.DeleteSObject/Definitions/Input.cs
+++ b/Frends.Salesforce.DeleteSObject/Frends.Salesforce.DeleteSObject/Definitions/Input.cs
@@ -17,6 +17,13 @@ public class Input
     public string Domain { get; set; }
 
     /// <summary>
+    /// The API version to use when making requests to Salesforce.
+    /// If left empty, the default value is v61.0.
+    /// </summary>
+    [DefaultValue("v61.0")]
+    public string ApiVersion { get; set; } = "v61.0";
+
+    /// <summary>
     /// SObject id.
     /// </summary>
     /// <example>abcdefghijkl123456789</example>

--- a/Frends.Salesforce.DeleteSObject/Frends.Salesforce.DeleteSObject/Definitions/Input.cs
+++ b/Frends.Salesforce.DeleteSObject/Frends.Salesforce.DeleteSObject/Definitions/Input.cs
@@ -9,7 +9,7 @@ public class Input
 {
     /// <summary>
     /// Salesforce Domain.
-    /// /services/data/v52.0/query will be added automatically, so the domain is enough.
+    /// /services/data/versionnumber/query will be added automatically, so the domain is enough.
     /// </summary>
     /// <example>https://example.my.salesforce.com</example>
     [DefaultValue(@"https://example.my.salesforce.com")]

--- a/Frends.Salesforce.DeleteSObject/Frends.Salesforce.DeleteSObject/DeleteSObject.cs
+++ b/Frends.Salesforce.DeleteSObject/Frends.Salesforce.DeleteSObject/DeleteSObject.cs
@@ -33,7 +33,7 @@ public class Salesforce
         if (string.IsNullOrWhiteSpace(input.SObjectId)) throw new ArgumentNullException("Id cannot be empty.");
         if (string.IsNullOrWhiteSpace(input.SObjectType)) throw new ArgumentNullException("Type cannot be empty.");
 
-        var client = new RestClient(input.Domain + "/services/data/v54.0/sobjects/" + input.SObjectType + "/" + input.SObjectId);
+        var client = new RestClient($"{input.Domain}/services/data/{input.ApiVersion}/sobjects/{input.SObjectType}/{input.SObjectId}");
         var request = new RestRequest("/", Method.Delete);
         string accessToken = "";
 

--- a/Frends.Salesforce.DeleteSObject/Frends.Salesforce.DeleteSObject/Frends.Salesforce.DeleteSObject.csproj
+++ b/Frends.Salesforce.DeleteSObject/Frends.Salesforce.DeleteSObject/Frends.Salesforce.DeleteSObject.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>1.0.1</Version>
+    <Version>2.0.0</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>


### PR DESCRIPTION
Closes #20 . Major version bump to 2.0.0. You can now specify API-version in the input-section. If left empty, the latest version as of today will be used (v61.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Users can now specify the Salesforce API version in the input parameters for enhanced flexibility and control.
	- A new property allows for defining the API version in requests, defaulting to "v61.0".

- **Bug Fixes**
	- Improved compatibility with different Salesforce API versions, ensuring more reliable interactions.

- **Tests**
	- Updated unit tests to consistently include the API version in delete operations, improving robustness and accuracy. 
	- New test cases added for various scenarios involving the API version parameter. 

- **Chores**
	- Project version updated from 1.0.1 to 2.0.0, indicating major updates and enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->