### PR TITLE
UpdateSObject - Added option to specify API version

### DIFF
--- a/Frends.Salesforce.UpdateSObject/CHANGELOG.md
+++ b/Frends.Salesforce.UpdateSObject/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.0] - 2024-08-19
+### Added
+- Salesforce API version number can now be specified in input.
+
 ## [1.0.0] - 2022-05-11
 ### Added
 - Initial implementation of Frends.Salesforce.UpdateSObject

--- a/Frends.Salesforce.UpdateSObject/Frends.Salesforce.UpdateSObject.Tests/UnitTests.cs
+++ b/Frends.Salesforce.UpdateSObject/Frends.Salesforce.UpdateSObject.Tests/UnitTests.cs
@@ -83,6 +83,18 @@ public class UnitTests
         _result.Add(new { Type = "Account", Id = id });
 
         var newInput = new { Name = "NewName_" + _name };
+        var result = await Salesforce.UpdateSObject(new Input { Domain = _domain, ApiVersion = "v61.0", SObjectId = id, SObjectType = "Account", SObjectAsJson = JsonSerializer.Serialize(newInput) }, _options, _cancellationToken);
+
+        Assert.IsTrue(result.RequestIsSuccessful);
+    }
+
+    [TestMethod]
+    public async Task UpdateAccountTest_WithoutSpecifiedApiVersion()
+    {
+        var id = await CreateSObject("Account", _userJson);
+        _result.Add(new { Type = "Account", Id = id });
+
+        var newInput = new { Name = "NewName_" + _name };
         var result = await Salesforce.UpdateSObject(new Input { Domain = _domain, SObjectId = id, SObjectType = "Account", SObjectAsJson = JsonSerializer.Serialize(newInput) }, _options, _cancellationToken);
 
         Assert.IsTrue(result.RequestIsSuccessful);
@@ -103,6 +115,7 @@ public class UnitTests
         var result = await Salesforce.UpdateSObject(new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectId = id,
             SObjectType = "Contact",
             SObjectAsJson = JsonSerializer.Serialize(
@@ -139,6 +152,7 @@ public class UnitTests
         var caseResult = await Salesforce.UpdateSObject(new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectId = caseId,
             SObjectType = "Case",
             SObjectAsJson = JsonSerializer.Serialize(
@@ -171,7 +185,7 @@ public class UnitTests
             Password = _password + _securityToken,
             ReturnAccessToken = true
         };
-        var result = await Salesforce.UpdateSObject(new Input { Domain = _domain, SObjectId = id, SObjectType = "Account", SObjectAsJson = JsonSerializer.Serialize(newInput) }, options, _cancellationToken);
+        var result = await Salesforce.UpdateSObject(new Input { Domain = _domain, ApiVersion = "v61.0", SObjectId = id, SObjectType = "Account", SObjectAsJson = JsonSerializer.Serialize(newInput) }, options, _cancellationToken);
 
         Assert.IsNotNull(result.Token);
     }
@@ -183,6 +197,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectId = "123456789",
             SObjectAsJson = _userJson,
             SObjectType = "Contact"
@@ -204,6 +219,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = null,
+            ApiVersion = "v61.0",
             SObjectId = "123456789",
             SObjectType = "Account"
         };
@@ -224,6 +240,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectId = null,
             SObjectType = "Account"
         };
@@ -244,6 +261,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectAsJson = null,
             SObjectType = "Account"
         };
@@ -264,6 +282,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectId = "123456789",
             SObjectType = ""
         };
@@ -284,6 +303,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = "https://mycompany.my.salesforce.com",
+            ApiVersion = "v61.0",
             SObjectId = "123456789",
             SObjectAsJson = _userJson,
             SObjectType = "Account"
@@ -309,6 +329,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = "https://example.my.salesforce.com",
+            ApiVersion = "v61.0",
             SObjectId = "123456789",
             SObjectAsJson = _userJson,
             SObjectType = "Account"
@@ -334,6 +355,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectId = "123456789",
             SObjectAsJson = _userJson,
             SObjectType = "InvalidType"
@@ -360,6 +382,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectId = "123456789",
             SObjectAsJson = _userJson,
             SObjectType = "Account"
@@ -386,6 +409,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectId = "Not valid id",
             SObjectAsJson = _userJson,
             SObjectType = "Account"
@@ -408,6 +432,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectAsJson = "Not valid json format",
             SObjectId = "123456789",
             SObjectType = "Account"
@@ -429,6 +454,7 @@ public class UnitTests
         var input = new Input
         {
             Domain = _domain,
+            ApiVersion = "v61.0",
             SObjectId = "123456789",
             SObjectType = "Account",
             SObjectAsJson = _userJson

--- a/Frends.Salesforce.UpdateSObject/Frends.Salesforce.UpdateSObject/Definitions/Input.cs
+++ b/Frends.Salesforce.UpdateSObject/Frends.Salesforce.UpdateSObject/Definitions/Input.cs
@@ -9,12 +9,19 @@ public class Input
 {
     /// <summary>
     /// Salesforce Domain.
-    /// /services/data/v52.0/query will be added automatically, so the domain is enough.
+    /// /services/data/versionnumber/query will be added automatically, so the domain is enough.
     /// </summary>
     /// <example>https://example.my.salesforce.com</example>
     [DefaultValue(@"https://example.my.salesforce.com")]
     [DisplayFormat(DataFormatString = "Text")]
     public string Domain { get; set; }
+
+    /// <summary>
+    /// The API version to use when making requests to Salesforce.
+    /// If left empty, the default value is v61.0.
+    /// </summary>
+    [DefaultValue("v61.0")]
+    public string ApiVersion { get; set; } = "v61.0";
 
     /// <summary>
     /// SObject structure as json.

--- a/Frends.Salesforce.UpdateSObject/Frends.Salesforce.UpdateSObject/Frends.Salesforce.UpdateSObject.csproj
+++ b/Frends.Salesforce.UpdateSObject/Frends.Salesforce.UpdateSObject/Frends.Salesforce.UpdateSObject.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>1.0.0</Version>
+    <Version>2.0.0</Version>
     <Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.Salesforce.UpdateSObject/Frends.Salesforce.UpdateSObject/UpdateSObject.cs
+++ b/Frends.Salesforce.UpdateSObject/Frends.Salesforce.UpdateSObject/UpdateSObject.cs
@@ -36,7 +36,7 @@ public class Salesforce
         if (string.IsNullOrWhiteSpace(input.SObjectAsJson)) throw new ArgumentNullException("Json cannot be empty.");
         if (string.IsNullOrWhiteSpace(input.SObjectType)) throw new ArgumentNullException("Type cannot be empty.");
 
-        var client = new RestClient(input.Domain + "/services/data/v54.0/sobjects/" + input.SObjectType + "/" + input.SObjectId);
+        var client = new RestClient($"{input.Domain}/services/data/{input.ApiVersion}/sobjects/{input.SObjectType}/{input.SObjectId}");
         var request = new RestRequest("/", Method.Patch);
         string accessToken = "";
 


### PR DESCRIPTION
Closes #18 . Major version bump to 2.0.0. You can now specify API-version in the input-section. If left empty, the latest version as of today will be used (v61.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to specify the Salesforce API version when updating objects, enhancing compatibility and flexibility.
  
- **Bug Fixes**
	- Updated documentation link for improved clarity and accuracy.

- **Chores**
	- Incremented module version from 1.0.0 to 2.0.0, reflecting significant updates and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->