### PR TITLE
Salesforce tasks - Documentation links fixed

### DIFF
--- a/Frends.Salesforce.CreateSObject/CHANGELOG.md
+++ b/Frends.Salesforce.CreateSObject/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.0] - 2024-08-28
+### Changed
+- Documentation link now links to a correct page in Frends Tasks.
+
 ## [1.0.1] - 2022-05-27
 ### Changed
 - Fix for issue with referencing result-object in other elements.

--- a/Frends.Salesforce.CreateSObject/Frends.Salesforce.CreateSObject/CreateSObject.cs
+++ b/Frends.Salesforce.CreateSObject/Frends.Salesforce.CreateSObject/CreateSObject.cs
@@ -15,7 +15,7 @@ public class Salesforce
 {
     /// <summary>
     /// Creates a sobject to Salesforce.
-    /// [Documentation](https://tasks.frends.com/tasks#frends-tasks/Frends.Salesforce.CreateSObject)
+    /// [Documentation](https://tasks.frends.com/tasks/frends-tasks/Frends.Salesforce.CreateSObject)
     /// </summary>
     /// <param name="input">Information to create the sobject.</param>
     /// <param name="options">Information about the salesforce destination.</param>

--- a/Frends.Salesforce.DeleteSObject/CHANGELOG.md
+++ b/Frends.Salesforce.DeleteSObject/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.0] - 2024-08-28
+### Changed
+- Documentation link now links to a correct page in Frends Tasks.
+
 ## [1.0.1] - 2022-05-27
 ### Changed
 - Fix for issue with referencing result-object in other elements.

--- a/Frends.Salesforce.DeleteSObject/Frends.Salesforce.DeleteSObject/DeleteSObject.cs
+++ b/Frends.Salesforce.DeleteSObject/Frends.Salesforce.DeleteSObject/DeleteSObject.cs
@@ -17,7 +17,7 @@ public class Salesforce
 {
     /// <summary>
     /// Deletes a sobject from Salesforce.
-    /// [Documentation](https://tasks.frends.com/tasks#frends-tasks/Frends.Salesforce.DeleteSObject)
+    /// [Documentation](https://tasks.frends.com/tasks/frends-tasks/Frends.Salesforce.DeleteSObject)
     /// </summary>
     /// <param name="input">Information to delete the sobject.</param>
     /// <param name="options">Information about the salesforce destination.</param>

--- a/Frends.Salesforce.ExecuteQuery/CHANGELOG.md
+++ b/Frends.Salesforce.ExecuteQuery/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.0] - 2024-08-28
+### Changed
+- Documentation link now links to a correct page in Frends Tasks.
+
 ## [1.0.1] - 2022-05-27
 ### Changed
 - Fix for issue with referencing result-object in other elements.

--- a/Frends.Salesforce.ExecuteQuery/Frends.Salesforce.ExecuteQuery/ExecuteQuery.cs
+++ b/Frends.Salesforce.ExecuteQuery/Frends.Salesforce.ExecuteQuery/ExecuteQuery.cs
@@ -17,7 +17,7 @@ public class Salesforce
 {
     /// <summary>
     /// Execute a query to Salesforce.
-    /// [Documentation](https://tasks.frends.com/tasks#frends-tasks/Frends.Salesforce.ExecuteQuery)
+    /// [Documentation](https://tasks.frends.com/tasks/frends-tasks/Frends.Salesforce.ExecuteQuery)
     /// </summary>
     /// <param name="input">Information to update the sobject.</param>
     /// <param name="options">Information about the salesforce destination.</param>

--- a/Frends.Salesforce.UpdateSObject/CHANGELOG.md
+++ b/Frends.Salesforce.UpdateSObject/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.0] - 2024-08-28
+### Changed
+- Documentation link now links to a correct page in Frends Tasks.
+
 ## [1.0.0] - 2022-05-11
 ### Added
 - Initial implementation of Frends.Salesforce.UpdateSObject

--- a/Frends.Salesforce.UpdateSObject/Frends.Salesforce.UpdateSObject/UpdateSObject.cs
+++ b/Frends.Salesforce.UpdateSObject/Frends.Salesforce.UpdateSObject/UpdateSObject.cs
@@ -19,7 +19,7 @@ public class Salesforce
 {
     /// <summary>
     /// Updates a sobject from Salesforce.
-    /// [Documentation](https://tasks.frends.com/tasks#frends-tasks/Frends.Salesforce.UpdateSObject)
+    /// [Documentation](https://tasks.frends.com/tasks/frends-tasks/Frends.Salesforce.UpdateSObject)
     /// </summary>
     /// <param name="input">Information to update the sobject.</param>
     /// <param name="options">Information about the salesforce destination.</param>


### PR DESCRIPTION
Closes #34 . Documentation links now work and at least redirect to a correct page in Frends Tasks. Changelogs modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated changelogs for `CreateSObject`, `DeleteSObject`, `ExecuteQuery`, and `UpdateSObject` modules to version 1.1.0, enhancing documentation accuracy with corrected links.
  
- **Documentation**
	- Improved documentation links for all mentioned modules to ensure users access the correct resources.
	- Minor adjustments made to URL formatting in documentation comments for consistency across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->